### PR TITLE
CXX standard in CMake

### DIFF
--- a/cmake/SIOBuild.cmake
+++ b/cmake/SIOBuild.cmake
@@ -1,4 +1,7 @@
 
+# Policy for "Support new ``if()`` IN_LIST operator"
+CMAKE_POLICY( SET CMP0057 NEW )
+
 MACRO( SIO_ADD_SHARED_LIBRARY _name )
   ADD_LIBRARY( ${_name} SHARED ${ARGN} )
   # change lib_target properties
@@ -233,7 +236,6 @@ SET( COMPILER_FLAGS
   -Wuninitialized
   -Wno-non-virtual-dtor
   -Wheader-hygiene
-  -std=c++11
 )
 
 IF( SIO_PROFILING AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
@@ -250,6 +252,21 @@ IF( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
  LIST( APPEND COMPILER_FLAGS -Wl,-no-undefined )
 ENDIF()
 
+# Dealing with CXX standard
+SET( SIO_POSSIBLE_CXX_STANDARDS 11 14 17 20 )
+LIST( GET SIO_POSSIBLE_CXX_STANDARDS 0 SIO_MINIMUM_CXX_REQUIRED )
+
+IF( CMAKE_CXX_STANDARD )
+  MESSAGE( STATUS "Checking CXX standard set by user ..." )
+  IF( NOT ${CMAKE_CXX_STANDARD} IN_LIST SIO_POSSIBLE_CXX_STANDARDS )
+    MESSAGE( FATAL_ERROR "Invalid cxx standard (set=${CMAKE_CXX_STANDARD}, minimum=${SIO_MINIMUM_CXX_REQUIRED})" )
+  ENDIF()
+ELSE()
+  MESSAGE( STATUS "Setting CXX standard to minimum required ..." )
+  SET( CMAKE_CXX_STANDARD ${SIO_MINIMUM_CXX_REQUIRED} )
+ENDIF()
+
+MESSAGE( STATUS "Using CXX standard ${CMAKE_CXX_STANDARD}" )
 
 MESSAGE( STATUS "FLAGS ${COMPILER_FLAGS}" )
 FOREACH( FLAG ${COMPILER_FLAGS} )
@@ -265,9 +282,6 @@ FOREACH( FLAG ${COMPILER_FLAGS} )
     ### We prepend the flag, so they are overwritten by whatever the user sets in his own configuration
     SET ( CMAKE_CXX_FLAGS "${FLAG} ${CMAKE_CXX_FLAGS}")
   ELSE()
-    IF( "${FLAG}" STREQUAL "-std=c++11" )
-      MESSAGE( FATAL_ERROR "Cannot add -std=c++11 to CMAKE_CXX_FLAGS, but c++11 is required, check your compiler" )
-    ENDIF()
     MESSAGE ( STATUS "NOT Adding ${FLAG} to CXX_FLAGS" )
   ENDIF()
 ENDFOREACH()

--- a/source/include/sio/buffer.h
+++ b/source/include/sio/buffer.h
@@ -3,6 +3,9 @@
 // -- sio headers
 #include <sio/definitions.h>
 
+// -- std headers
+#include <limits>
+
 namespace sio {
 
   /**
@@ -172,6 +175,15 @@ namespace sio {
      *  @param  count the size of the subspan
      */
     buffer_span subspan( index_type start, std::size_t count ) const ;
+    
+    /**
+     *  @brief  Dump the buffer into standard output
+     *  
+     *  @param  base the numeric base of the output data (default octal)
+     *  @param  line_split the number of bytes to print before a line break
+     *  @param  max_bytes the maximum number of bytes to printout
+     */
+    void dump( int base = 8, unsigned int line_split = 20, size_type max_bytes = std::numeric_limits<size_type>::max() ) ;
     ///@}
 
   private:

--- a/source/include/sio/definitions.h
+++ b/source/include/sio/definitions.h
@@ -262,25 +262,25 @@ namespace sio {
 #endif
 
 #if SIO_LOGLVL > 3
-#define SIO_DEBUG( message ) std::cout << "[SIO DEBUG] - " << message << std::endl
+#define SIO_DEBUG( message ) std::cout << "[SIO DEBUG] " << __FUNCTION__ << " - " << message << std::endl
 #else
 #define SIO_DEBUG( message )
 #endif
 
 #if SIO_LOGLVL > 2
-#define SIO_INFO( message ) std::cout << "[SIO INFO] - " << message << std::endl
+#define SIO_INFO( message ) std::cout << "[SIO INFO] - "  << __FUNCTION__ << " - " << message << std::endl
 #else
 #define SIO_INFO( message )
 #endif
 
 #if SIO_LOGLVL > 1
-#define SIO_WARNING( message ) std::cout << "[SIO WARNING] - " << message << std::endl
+#define SIO_WARNING( message ) std::cout << "[SIO WARNING] - "  << __FUNCTION__ << " - " << message << std::endl
 #else
 #define SIO_WARNING( message )
 #endif
 
 #if SIO_LOGLVL > 0
-#define SIO_ERROR( message ) std::cout << "[SIO ERROR] - " << message << std::endl
+#define SIO_ERROR( message ) std::cout << "[SIO ERROR] - "  << __FUNCTION__ << " - " << message << std::endl
 #else
 #define SIO_ERROR( message )
 #endif

--- a/source/src/api.cc
+++ b/source/src/api.cc
@@ -257,7 +257,7 @@ namespace sio {
     // check for a block marker
     if( sio::block_marker != marker ) {
       std::stringstream ss ;
-      ss << "Block marker not found (expected " << sio::block_marker <<", got " << marker << ")" ;
+      ss << "Block marker not found (block marker: " << sio::block_marker <<", record marker: " << sio::record_marker << ", got " << marker << ")" ;
       SIO_THROW( sio::error_code::no_marker, ss.str() ) ;
     }
     device.data( info._version ) ;

--- a/source/src/buffer.cc
+++ b/source/src/buffer.cc
@@ -4,6 +4,7 @@
 
 // -- std headers
 #include <sstream>
+#include <iomanip>
 
 namespace sio {
 
@@ -133,6 +134,23 @@ namespace sio {
       SIO_THROW( error_code::out_of_range, ss.str() ) ;
     }
     return buffer_span( std::next(_first, start) , std::next(_first, start+count) ) ;
+  }
+  
+  //--------------------------------------------------------------------------
+  
+  void buffer_span::dump( int base, unsigned int line_split, size_type max_bytes ) {
+    std::ios_base::fmtflags f( std::cout.flags() );
+    for( size_type i=0 ; i<size() ; i++ ) {
+      std::cout << std::setbase( base ) << (int)at(i) << " " ;
+      if( (i != 0) and (i%line_split == 0) ) {
+        std::cout << std::endl ;
+      }
+      if( i > max_bytes ) {
+        break ;
+      }
+    }
+    std::cout << std::endl ;
+    std::cout.flags( f );
   }
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION

BEGINRELEASENOTES
- Added `buffer_span::dump` for debugging
- More debug printout
- CMake: Reviewed way of setting the CXX standard

ENDRELEASENOTES