### PR TITLE
Fixed buffer overflow issue

### DIFF
--- a/source/examples/common/include/sioexamples/blocks.h
+++ b/source/examples/common/include/sioexamples/blocks.h
@@ -58,6 +58,9 @@ namespace sio {
     
     class linked_list_block : public sio::block {
     public:
+      linked_list_block(const linked_list_block &) = delete ;
+      linked_list_block &operator=(const linked_list_block &) = delete ;
+      
       linked_list_block() :
         sio::block( "linked_list", sio::version::encode_version( 1, 2 ) ) {
         /* nop */

--- a/source/examples/common/include/sioexamples/blocks.h
+++ b/source/examples/common/include/sioexamples/blocks.h
@@ -62,9 +62,25 @@ namespace sio {
         sio::block( "linked_list", sio::version::encode_version( 1, 2 ) ) {
         /* nop */
       }
+      
+      ~linked_list_block() {
+        if( nullptr != _root ) {
+          delete _root ;
+          _root = nullptr ;
+        }
+      }
     
-      std::shared_ptr<linked_list> root() const { return _root ; }
-      void set_root( std::shared_ptr<linked_list> r ) { _root = r ; }
+      linked_list *root() const { 
+        return _root ; 
+      }
+      
+      void set_root( linked_list *r ) { 
+        if( nullptr != _root ) {
+          delete _root ;
+          _root = nullptr ;
+        }
+        _root = r ; 
+      }
     
       // Read the linked_list data from the device
       void read( sio::read_device &device, sio::version_type /*vers*/ ) override {
@@ -72,13 +88,17 @@ namespace sio {
         // read the number of elements in the linked list
         SIO_SDATA( device, nlinks ) ;
         // create the root element
-        _root = std::make_shared<linked_list>() ;
+        if( nullptr != _root ) {
+          delete _root ;
+          _root = nullptr ;
+        }
+        _root = new linked_list() ;
         auto current = _root ;
         for( int i=0 ; i<nlinks ; i++ ) {
           linked_list_data( current, device ) ;
           // last element ? then don't allocate the next of the list
           if( i+1 < nlinks ) {
-            current->_next = std::make_shared<linked_list>() ;
+            current->_next = new linked_list() ;
           }
           current = current->_next ;     
         }
@@ -103,7 +123,7 @@ namespace sio {
     
     private:
       ///< The linked_list data to read/write
-      std::shared_ptr<linked_list>            _root {nullptr} ;
+      linked_list                    *_root {nullptr} ;
     };
     
   }

--- a/source/examples/common/include/sioexamples/data.h
+++ b/source/examples/common/include/sioexamples/data.h
@@ -32,25 +32,29 @@ namespace sio {
     }
     
     // simple example of data referencing another 
-    // data structure with a pointer. The shared_ptr
-    // is just there to make the ownership clearer
+    // data structure with a pointer.
     struct linked_list {
+      ~linked_list() {
+        if( nullptr != _next ) {
+          delete _next ;
+          _next = nullptr ;
+        }
+      }
       std::string                      _name {} ;
-      std::shared_ptr<linked_list>     _next {nullptr} ;
+      linked_list                     *_next {nullptr} ;
     };
     
     /// Read or write linked_list data with the device
     template <typename devT>
-    inline void linked_list_data( std::shared_ptr<linked_list> l, devT &device ) {
+    inline void linked_list_data( linked_list *l, devT &device ) {
       // read/write name field
       SIO_SDATA( device, l->_name ) ;
       // read/write a pointer member. This object won't allocated on read
       // but relocated after all data have been read from a record
-      auto ptr = l->_next.get() ;
-      SIO_PNTR( device, &ptr ) ;
+      SIO_PNTR( device, &l->_next ) ;
       // the linked list pointer itself can be referenced by other structures
       // read/write the address of this object
-      SIO_PTAG( device, l.get() ) ;
+      SIO_PTAG( device, l ) ;
 
     }
     

--- a/source/examples/common/include/sioexamples/data.h
+++ b/source/examples/common/include/sioexamples/data.h
@@ -34,6 +34,7 @@ namespace sio {
     // simple example of data referencing another 
     // data structure with a pointer.
     struct linked_list {
+      linked_list() = default ;
       linked_list(const linked_list &) = delete ;
       linked_list &operator=(const linked_list &) = delete ;
       ~linked_list() {

--- a/source/examples/common/include/sioexamples/data.h
+++ b/source/examples/common/include/sioexamples/data.h
@@ -34,6 +34,8 @@ namespace sio {
     // simple example of data referencing another 
     // data structure with a pointer.
     struct linked_list {
+      linked_list(const linked_list &) = delete ;
+      linked_list &operator=(const linked_list &) = delete ;
       ~linked_list() {
         if( nullptr != _next ) {
           delete _next ;

--- a/source/examples/relocation/relocation_write.cc
+++ b/source/examples/relocation/relocation_write.cc
@@ -43,14 +43,14 @@ int main( int argc, char **argv ) {
     
     /// Create a linked list of 200 elements
     int n = 200 ;
-    auto llroot = std::make_shared<sio::example::linked_list>() ;
+    auto llroot = new sio::example::linked_list() ;
     auto llcur = llroot ;
     for( int i=0 ; i<n ; i++ ) {
       llcur->_name = "element_" + std::to_string( i ) ;
       std::cout << "Created element in linked list with name: " << llcur->_name << std::endl ;
       if( i+1 < n ) {
         std::cout << "Creating next element..." << std::endl ;
-        llcur->_next = std::make_shared<sio::example::linked_list>() ;
+        llcur->_next = new sio::example::linked_list() ;
       }
       else {
         std::cout << "It was the last element" << std::endl ;


### PR DESCRIPTION
BEGINRELEASENOTES
- Examples:
    - Turned example structure linked_list to normal pointer
    - Fixed buffer overflow issue
- **Important for documentation: pointer relocation using smart pointers** (`std::shared_ptr<T>` and co) **is not supported** 

ENDRELEASENOTES