### PR TITLE
[cmake] install cmake files under lib/cmake/SIO

### DIFF
--- a/cmake/SIOBuild.cmake
+++ b/cmake/SIOBuild.cmake
@@ -108,7 +108,7 @@ MACRO( SIO_GENERATE_PACKAGE_CONFIGURATION_FILES )
         CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                         "${PROJECT_BINARY_DIR}/${arg}" @ONLY
         )
-        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake )
       ENDIF()
     ENDIF()
     IF( ${arg} MATCHES "ConfigVersion.cmake" )
@@ -117,7 +117,7 @@ MACRO( SIO_GENERATE_PACKAGE_CONFIGURATION_FILES )
         CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                         "${PROJECT_BINARY_DIR}/${arg}" @ONLY
         )
-        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake )
       ENDIF()
     ENDIF()
   ENDFOREACH()

--- a/cmake/SIOBuild.cmake
+++ b/cmake/SIOBuild.cmake
@@ -108,7 +108,11 @@ MACRO( SIO_GENERATE_PACKAGE_CONFIGURATION_FILES )
         CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                         "${PROJECT_BINARY_DIR}/${arg}" @ONLY
         )
-        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake )
+        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+        # some releases (like LCG) create a filesystem projection (view)
+        # that ignores files installed to .
+        # install the same file again to another "view-safe" location as a workaround 
+        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake/SIO )
       ENDIF()
     ENDIF()
     IF( ${arg} MATCHES "ConfigVersion.cmake" )
@@ -117,6 +121,10 @@ MACRO( SIO_GENERATE_PACKAGE_CONFIGURATION_FILES )
         CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                         "${PROJECT_BINARY_DIR}/${arg}" @ONLY
         )
+        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+        # some releases (like LCG) create a filesystem projection (view)
+        # that ignores files installed to .
+        # install the same file again to another "view-safe" location as a workaround 
         INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake )
       ENDIF()
     ENDIF()

--- a/cmake/SIOBuild.cmake
+++ b/cmake/SIOBuild.cmake
@@ -125,7 +125,7 @@ MACRO( SIO_GENERATE_PACKAGE_CONFIGURATION_FILES )
         # some releases (like LCG) create a filesystem projection (view)
         # that ignores files installed to .
         # install the same file again to another "view-safe" location as a workaround 
-        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake )
+        INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake/SIO )
       ENDIF()
     ENDIF()
   ENDFOREACH()


### PR DESCRIPTION
Installing things in the install prefix creates problems when sio is projected on a filesystem view, as is done for the lcg releases.
Not sure if this is the optimal solution, but lib/cmake is already used by the project, and it should workaround current install issues.  
BEGINRELEASENOTES
-  install cmake files under lib/cmake/SIO

ENDRELEASENOTES