### PR TITLE
Add missing includes and remove includes that are not needed

### DIFF
--- a/source/examples/relocation/relocation_read.cc
+++ b/source/examples/relocation/relocation_read.cc
@@ -2,10 +2,15 @@
 #include <sio/definitions.h>
 #include <sio/exception.h>
 #include <sio/api.h>
-
+#include <sio/buffer.h>
 // -- sio examples headers
 #include <sioexamples/data.h>
 #include <sioexamples/blocks.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
 
 /**
  *  This example illustrate how to read a simple data structure.

--- a/source/examples/relocation/relocation_write.cc
+++ b/source/examples/relocation/relocation_write.cc
@@ -2,10 +2,14 @@
 #include <sio/definitions.h>
 #include <sio/exception.h>
 #include <sio/api.h>
-
+#include <sio/buffer.h>
 // -- sio examples headers
 #include <sioexamples/data.h>
 #include <sioexamples/blocks.h>
+#include <iostream>
+#include <memory>
+#include <string>
+
 
 /**
  *  This example illustrate how to write a simple data structure.

--- a/source/examples/simple/simple_read.cc
+++ b/source/examples/simple/simple_read.cc
@@ -2,10 +2,14 @@
 #include <sio/definitions.h>
 #include <sio/exception.h>
 #include <sio/api.h>
-
+#include <sio/buffer.h>
 // -- sio examples headers
 #include <sioexamples/data.h>
 #include <sioexamples/blocks.h>
+#include <iostream>
+#include <memory>
+#include <string>
+
 
 /**
  *  This example illustrate how to read a simple data structure.

--- a/source/examples/simple/simple_write.cc
+++ b/source/examples/simple/simple_write.cc
@@ -2,10 +2,14 @@
 #include <sio/definitions.h>
 #include <sio/exception.h>
 #include <sio/api.h>
-
+#include <sio/buffer.h>
 // -- sio examples headers
 #include <sioexamples/data.h>
 #include <sioexamples/blocks.h>
+#include <iostream>
+#include <memory>
+#include <string>
+
 
 /**
  *  This example illustrate how to write a simple data structure.

--- a/source/examples/zlib/zlib_read.cc
+++ b/source/examples/zlib/zlib_read.cc
@@ -3,10 +3,14 @@
 #include <sio/exception.h>
 #include <sio/api.h>
 #include <sio/compression/zlib.h>
-
+#include <sio/buffer.h>
 // -- sio examples headers
 #include <sioexamples/data.h>
 #include <sioexamples/blocks.h>
+#include <iostream>
+#include <memory>
+#include <string>
+
 
 /**
  *  This example illustrate how to read a simple data structure and 

--- a/source/examples/zlib/zlib_write.cc
+++ b/source/examples/zlib/zlib_write.cc
@@ -3,10 +3,14 @@
 #include <sio/exception.h>
 #include <sio/api.h>
 #include <sio/compression/zlib.h>
-
+#include <sio/buffer.h>
 // -- sio examples headers
 #include <sioexamples/data.h>
 #include <sioexamples/blocks.h>
+#include <iostream>
+#include <memory>
+#include <string>
+
 
 /**
  *  This example illustrate how to write a simple data structure and 

--- a/source/include/sio/api.h
+++ b/source/include/sio/api.h
@@ -3,13 +3,13 @@
 // -- sio headers
 #include <sio/definitions.h>
 #include <sio/buffer.h>
-
 // -- std headers
-#include <memory>
 #include <utility>
 #include <string>
 #include <sstream>
 #include <vector>
+#include <algorithm>
+#include <cstddef>
 
 namespace sio {
 

--- a/source/include/sio/buffer.h
+++ b/source/include/sio/buffer.h
@@ -2,9 +2,10 @@
 
 // -- sio headers
 #include <sio/definitions.h>
-
 // -- std headers
 #include <limits>
+#include <cstddef>
+#include <vector>
 
 namespace sio {
 

--- a/source/include/sio/io_device.h
+++ b/source/include/sio/io_device.h
@@ -3,6 +3,9 @@
 // -- sio headers
 #include <sio/definitions.h>
 #include <sio/buffer.h>
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace sio {
 

--- a/source/include/sio/version.h
+++ b/source/include/sio/version.h
@@ -2,6 +2,7 @@
 
 // -- sio headers
 #include <sio/definitions.h>
+#include <cstdint>
 
 namespace sio {
 

--- a/source/main/sio-dump.cc
+++ b/source/main/sio-dump.cc
@@ -1,9 +1,7 @@
 // -- sio headers
 #include <sio/definitions.h>
-#include <sio/buffer.h>
 #include <sio/api.h>
-#include <sio/compression/zlib.h>
-
+#include <sio/exception.h>
 // -- std headers
 #include <limits>
 #include <vector>
@@ -11,6 +9,9 @@
 #include <algorithm>
 #include <iterator>
 #include <iostream>
+#include <cstdlib>
+#include <stdexcept>
+
 
 
 constexpr const char *USAGE = R"(Usage: sio-dump [-d/--detailed] [-n NRECORDS] [-m SKIPRECORDS] siofile)";

--- a/source/src/api.cc
+++ b/source/src/api.cc
@@ -7,13 +7,18 @@
 #include <sio/compression/zlib.h>
 #include <sio/block.h>
 #include <sio/version.h>
-
+#include <sio/definitions.h>
 // -- std headers
 #include <iostream>
 #include <iomanip>
-#include <limits>
 #include <string>
 #include <algorithm>
+#include <memory>
+#include <cstddef>
+#include <string>
+#include <vector>
+#include <utility>
+
 
 namespace sio {
 

--- a/source/src/block.cc
+++ b/source/src/block.cc
@@ -2,6 +2,8 @@
 #include <sio/block.h>
 #include <sio/exception.h>
 
+#include <sio/definitions.h>
+
 namespace sio {
   
   block::block( const std::string &nam, sio::version_type vers ) :

--- a/source/src/buffer.cc
+++ b/source/src/buffer.cc
@@ -1,10 +1,14 @@
 // -- sio headers
 #include <sio/buffer.h>
 #include <sio/exception.h>
-
+#include <sio/definitions.h>
 // -- std headers
 #include <sstream>
 #include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <utility>
+
 
 namespace sio {
 

--- a/source/src/compression/zlib.cc
+++ b/source/src/compression/zlib.cc
@@ -1,14 +1,14 @@
 #include <sio/compression/zlib.h>
-
 // -- sio headers
 #include <sio/buffer.h>
 #include <sio/exception.h>
-
+#include <sio/definitions.h>
 // -- zlib headers
 #include <zlib.h>
-
+#include <zconf.h>
 // -- std headers
 #include <sstream>
+
 
 namespace sio {
 

--- a/source/src/io_device.cc
+++ b/source/src/io_device.cc
@@ -1,6 +1,11 @@
 // -- sio headers
 #include <sio/io_device.h>
 #include <sio/api.h>
+#include <sio/buffer.h>
+#include <sio/definitions.h>
+#include <sio/exception.h>
+#include <utility>
+
 
 namespace sio {
 

--- a/source/src/memcpy.cc
+++ b/source/src/memcpy.cc
@@ -1,5 +1,7 @@
 // -- sio headers
 #include <sio/memcpy.h>
+#include <sio/definitions.h>
+
 
 namespace sio {
 


### PR DESCRIPTION
It seems I've had these changes for a long time in my clone.

BEGINRELEASENOTES
- Add missing includes and remove includes that are not needed

ENDRELEASENOTES

I can compile fine locally with Clang 21 and GCC 15. On Alma 9 it works with GCC 14.